### PR TITLE
Ignore unused_assignment warning

### DIFF
--- a/docsplay-macros/src/expand.rs
+++ b/docsplay-macros/src/expand.rs
@@ -365,7 +365,7 @@ fn impl_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream> {
                 fn fmt(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     #import
 
-                    #[allow(unused_variables)]
+                    #[allow(unused_variables, unused_assignments)]
                     match self {
                         #(#arms,)*
                     }


### PR DESCRIPTION
On Rust 1.92 and newer, using `docsplay` leads to a weird warning for me, like:

```rust
warning: value assigned to `source` is never read
  --> probe-rs/src/architecture/arm/mod.rs:69:9
   |
69 |         source: AccessPortError,
   |         ^^^^^^
   |
   = help: maybe it is overwritten before being read?
   = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default
```

See <https://github.com/rust-lang/rust/issues/151514>, this seems like a regression in rustc, but allowing that warning would be a workaround.